### PR TITLE
Implements verse text-to-speech with language options

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -29,7 +29,7 @@ export function ThemeToggle() {
 		<label className="switch">
 			<input
 				type="checkbox"
-				checked={isDark}
+				checked={!isDark}
 				onChange={toggleTheme}
 				aria-label="Toggle dark mode"
 			/>


### PR DESCRIPTION
Adds text-to-speech capabilities to the Chapter Page, enabling users to listen to verse content. Users can select from Hindi, English, and Sanskrit (with Hindi voice) for audio playback. Includes play/pause controls and intelligent text selection based on the chosen language. Ensures proper speech cleanup when navigating or unmounting.

Also corrects the theme toggle checkbox logic to accurately reflect the current theme.

<img width="1792" height="1120" alt="Screenshot 2025-08-07 at 9 06 57 PM" src="https://github.com/user-attachments/assets/b9c22306-00e7-4374-866d-9b511cf18fb1" />
<img width="1792" height="1120" alt="Screenshot 2025-08-07 at 10 38 54 PM" src="https://github.com/user-attachments/assets/fa6dee46-85ef-4e4f-a073-d0e746d268e8" />
